### PR TITLE
Add baseline, tree, and LSTM models with evaluation utilities

### DIFF
--- a/building-cooling-prediction/models/model_configs/lightgbm_config.json
+++ b/building-cooling-prediction/models/model_configs/lightgbm_config.json
@@ -1,1 +1,5 @@
-  
+{
+    "n_estimators": 100,
+    "learning_rate": 0.1,
+    "num_leaves": 31
+}

--- a/building-cooling-prediction/models/model_configs/lstm_config.json
+++ b/building-cooling-prediction/models/model_configs/lstm_config.json
@@ -1,1 +1,5 @@
-  
+{
+    "units": 50,
+    "epochs": 10,
+    "batch_size": 32
+}

--- a/building-cooling-prediction/models/model_configs/xgboost_config.json
+++ b/building-cooling-prediction/models/model_configs/xgboost_config.json
@@ -1,1 +1,6 @@
-  
+{
+    "n_estimators": 100,
+    "max_depth": 3,
+    "learning_rate": 0.1,
+    "subsample": 1.0
+}

--- a/building-cooling-prediction/notebooks/04_model_development.ipynb
+++ b/building-cooling-prediction/notebooks/04_model_development.ipynb
@@ -1,1 +1,29 @@
-  
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Development\n",
+    "This notebook documents baseline, tree-based, and deep learning models used for building cooling load prediction.\n",
+    "\n",
+    "## Baseline Models\n",
+    "- Mean predictor\n",
+    "- Last value predictor\n",
+    "- Linear regression baseline\n",
+    "\n",
+    "## Tree-Based Models\n",
+    "- XGBoost\n",
+    "- LightGBM\n",
+    "\n",
+    "## Deep Learning Models\n",
+    "- LSTM network\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {"name": "python"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/building-cooling-prediction/notebooks/05_model_evaluation.ipynb
+++ b/building-cooling-prediction/notebooks/05_model_evaluation.ipynb
@@ -1,1 +1,27 @@
-  
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Evaluation\n",
+    "This notebook outlines the evaluation framework, including metrics and validation strategies.\n",
+    "\n",
+    "## Metrics\n",
+    "- Normalized Root Mean Square Error (NRMSE)\n",
+    "\n",
+    "## Validation Strategies\n",
+    "- Train/test split\n",
+    "- K-fold cross-validation\n",
+    "\n",
+    "## Visualization\n",
+    "Prediction and residual plots can be generated with utility functions.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {"name": "python"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/building-cooling-prediction/reports/feature_importance.md
+++ b/building-cooling-prediction/reports/feature_importance.md
@@ -1,1 +1,3 @@
-  
+# Feature Importance
+
+Insights into which features contribute most to cooling load predictions.

--- a/building-cooling-prediction/reports/model_performance.md
+++ b/building-cooling-prediction/reports/model_performance.md
@@ -1,1 +1,3 @@
-  
+# Model Performance
+
+Evaluation metrics and comparison across models. Figures are saved in `reports/figures/` when generated.

--- a/building-cooling-prediction/src/evaluation/metrics.py
+++ b/building-cooling-prediction/src/evaluation/metrics.py
@@ -1,1 +1,15 @@
-  
+import numpy as np
+from sklearn.metrics import mean_squared_error
+
+
+def rmse(y_true, y_pred):
+    """Root mean squared error."""
+    return mean_squared_error(y_true, y_pred, squared=False)
+
+
+def nrmse(y_true, y_pred):
+    """Normalized root mean squared error."""
+    denominator = np.max(y_true) - np.min(y_true)
+    if denominator == 0:
+        return np.nan
+    return rmse(y_true, y_pred) / denominator

--- a/building-cooling-prediction/src/evaluation/validation.py
+++ b/building-cooling-prediction/src/evaluation/validation.py
@@ -1,1 +1,20 @@
-  
+from typing import Iterator, Tuple, Optional
+
+import numpy as np
+from sklearn.model_selection import KFold, train_test_split
+
+
+def simple_train_test_split(X, y, test_size: float = 0.2, random_state: int = 42):
+    return train_test_split(X, y, test_size=test_size, random_state=random_state)
+
+
+def k_fold_split(
+    X,
+    y,
+    n_splits: int = 5,
+    shuffle: bool = True,
+    random_state: Optional[int] = 42,
+) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+    kf = KFold(n_splits=n_splits, shuffle=shuffle, random_state=random_state)
+    for train_idx, test_idx in kf.split(X):
+        yield train_idx, test_idx

--- a/building-cooling-prediction/src/evaluation/visualization.py
+++ b/building-cooling-prediction/src/evaluation/visualization.py
@@ -1,1 +1,24 @@
-  
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+
+def plot_predictions(y_true, y_pred, save_path: str):
+    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+    plt.figure()
+    plt.plot(y_true, label='Actual')
+    plt.plot(y_pred, label='Predicted')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()
+
+
+def plot_residuals(y_true, y_pred, save_path: str):
+    residuals = y_true - y_pred
+    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+    plt.figure()
+    plt.plot(residuals)
+    plt.title('Residuals')
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()

--- a/building-cooling-prediction/src/models/baseline_models.py
+++ b/building-cooling-prediction/src/models/baseline_models.py
@@ -1,1 +1,43 @@
-  
+import numpy as np
+from dataclasses import dataclass
+from sklearn.linear_model import LinearRegression
+
+
+@dataclass
+class MeanBaseline:
+    """Predicts the mean of the training targets."""
+    mean_value_: float = 0.0
+
+    def fit(self, y):
+        self.mean_value_ = float(np.mean(y))
+        return self
+
+    def predict(self, X):
+        return np.full(shape=len(X), fill_value=self.mean_value_)
+
+
+@dataclass
+class LastValueBaseline:
+    """Predicts using the last observed target value."""
+    last_value_: float = 0.0
+
+    def fit(self, y):
+        self.last_value_ = float(y[-1])
+        return self
+
+    def predict(self, X):
+        return np.full(shape=len(X), fill_value=self.last_value_)
+
+
+class LinearRegressionBaseline:
+    """Wrapper around scikit-learn's LinearRegression."""
+
+    def __init__(self):
+        self.model = LinearRegression()
+
+    def fit(self, X, y):
+        self.model.fit(X, y)
+        return self
+
+    def predict(self, X):
+        return self.model.predict(X)

--- a/building-cooling-prediction/src/models/deep_learning.py
+++ b/building-cooling-prediction/src/models/deep_learning.py
@@ -1,1 +1,50 @@
-  
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import LSTM, Dense
+    from tensorflow.keras.callbacks import EarlyStopping
+except ImportError:  # pragma: no cover - optional dependency
+    Sequential = None
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent.parent / 'models' / 'model_configs'
+MODEL_DIR = Path(__file__).resolve().parent.parent.parent / 'models' / 'trained_models'
+
+
+def save_config(config: Dict[str, Any]):
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    path = CONFIG_DIR / 'lstm_config.json'
+    with open(path, 'w') as f:
+        json.dump(config, f, indent=4)
+
+
+def build_lstm_model(input_shape, units: int = 50, output_dim: int = 1):
+    if Sequential is None:
+        raise ImportError('TensorFlow is not installed')
+    model = Sequential([
+        LSTM(units, input_shape=input_shape),
+        Dense(output_dim)
+    ])
+    model.compile(optimizer='adam', loss='mse')
+    return model
+
+
+def train_lstm(X_train, y_train, config: Optional[Dict[str, Any]] = None):
+    if config is None:
+        config = {"units": 50, "epochs": 10, "batch_size": 32}
+    save_config(config)
+    model = build_lstm_model(input_shape=X_train.shape[1:], units=config["units"])
+    callbacks = [EarlyStopping(patience=3, restore_best_weights=True)]
+    model.fit(
+        X_train,
+        y_train,
+        epochs=config["epochs"],
+        batch_size=config["batch_size"],
+        callbacks=callbacks,
+        verbose=0,
+    )
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    model.save(MODEL_DIR / 'lstm_model.h5')
+    return model

--- a/building-cooling-prediction/src/models/tree_models.py
+++ b/building-cooling-prediction/src/models/tree_models.py
@@ -1,1 +1,53 @@
-  
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    import xgboost as xgb
+except ImportError:  # pragma: no cover - optional dependency
+    xgb = None
+
+try:
+    import lightgbm as lgb
+except ImportError:  # pragma: no cover - optional dependency
+    lgb = None
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent.parent / 'models' / 'model_configs'
+MODEL_DIR = Path(__file__).resolve().parent.parent.parent / 'models' / 'trained_models'
+
+
+def load_config(name: str) -> Dict[str, Any]:
+    path = CONFIG_DIR / f"{name}_config.json"
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_config(name: str, config: Dict[str, Any]):
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    path = CONFIG_DIR / f"{name}_config.json"
+    with open(path, 'w') as f:
+        json.dump(config, f, indent=4)
+
+
+def train_xgboost(X_train, y_train, **override_params):
+    if xgb is None:
+        raise ImportError('xgboost is not installed')
+    config = load_config('xgboost')
+    config.update(override_params)
+    model = xgb.XGBRegressor(**config)
+    model.fit(X_train, y_train)
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    model.save_model(MODEL_DIR / 'xgboost_model.json')
+    return model
+
+
+def train_lightgbm(X_train, y_train, **override_params):
+    if lgb is None:
+        raise ImportError('lightgbm is not installed')
+    config = load_config('lightgbm')
+    config.update(override_params)
+    model = lgb.LGBMRegressor(**config)
+    model.fit(X_train, y_train)
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    model.booster_.save_model(str(MODEL_DIR / 'lightgbm_model.txt'))
+    return model


### PR DESCRIPTION
## Summary
- Implement baseline predictors (mean, last value, linear regression)
- Add XGBoost, LightGBM, and LSTM training utilities with configs
- Provide NRMSE metric, validation helpers, and visualization functions
- Document model development and evaluation workflows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4b187d1608328a34533046f35befb